### PR TITLE
Fix reader calculation error with getting releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,5 @@
       "name": "Matthew Erwin",
       "email": "m@tthewerwin.com"
     }
-  ],
-  "conflict": {
-    "phpunit/php-timer": ">=2"
-  }
+  ]
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
       "name": "Matthew Erwin",
       "email": "m@tthewerwin.com"
     }
-  ]
+  ],
+  "conflict": {
+    "phpunit/php-timer": ">=2"
+  }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -34,7 +34,11 @@ class Reader
             {
                 $start = key($headings);
                 next($headings);
-                $end = key($headings) - 1;
+                $end = key($headings);
+
+                if ($end) {
+                    $end -= $start;
+                }
 
                 $release_content = array_slice($this->content, $start, $end);
 


### PR DESCRIPTION
`array_slice` third argument for end is length of slice, not the total length from the beginning of the original array being sliced. This PR corrects that calculation so that the right number of lines from the markdown are retrieved per release.